### PR TITLE
Add multi-repo support with Gist-based question loading

### DIFF
--- a/src/data/gistLoader.js
+++ b/src/data/gistLoader.js
@@ -1,0 +1,88 @@
+import https from 'https';
+
+/**
+ * Fetches quiz data (categories + questions) from a GitHub Gist.
+ * Expects the gist to export `categories` and `questions` in JS module format.
+ */
+export async function loadQuestionsFromGist(gistId) {
+  const apiUrl = `https://api.github.com/gists/${gistId}`;
+  const raw = await fetchJSON(apiUrl);
+
+  // Find the questions file in the gist
+  const files = Object.values(raw.files);
+  const questionsFile = files.find(f => f.filename.includes('questions'));
+  if (!questionsFile) {
+    throw new Error(`No questions file found in gist ${gistId}`);
+  }
+
+  // If content is truncated, fetch from raw_url
+  let content = questionsFile.content;
+  if (questionsFile.truncated && questionsFile.raw_url) {
+    content = await fetchText(questionsFile.raw_url);
+  }
+
+  return parseQuestionsJS(content);
+}
+
+/**
+ * Parses a JS module string that exports `categories` and `questions`.
+ * Strips export keywords and evaluates the data structures.
+ */
+function parseQuestionsJS(jsContent) {
+  // Remove 'export' keywords so we can evaluate the objects
+  let code = jsContent
+    .replace(/export\s+const\s+/g, 'const ')
+    .replace(/export\s+/g, '');
+
+  // Use Function constructor to safely evaluate the JS objects
+  const fn = new Function(`
+    ${code}
+    return { categories, questions };
+  `);
+
+  const result = fn();
+
+  // Normalize question types: 'boolean' -> 'truefalse'
+  result.questions = result.questions.map(q => ({
+    ...q,
+    type: q.type === 'boolean' ? 'truefalse' : q.type
+  }));
+
+  return result;
+}
+
+function fetchJSON(url) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      headers: { 'User-Agent': 'shipment-quiz-bot' }
+    };
+    https.get(url, options, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(data));
+        } catch (e) {
+          reject(new Error(`Failed to parse JSON from ${url}: ${e.message}`));
+        }
+      });
+    }).on('error', reject);
+  });
+}
+
+function fetchText(url) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      headers: { 'User-Agent': 'shipment-quiz-bot' }
+    };
+    https.get(url, options, (res) => {
+      // Follow redirects
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        return fetchText(res.headers.location).then(resolve).catch(reject);
+      }
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve(data));
+    }).on('error', reject);
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,58 @@
 import { Telegraf, Markup } from 'telegraf';
 import dotenv from 'dotenv';
-import { categories, questions } from './data/questions.js';
+import { categories as shipmentCategories, questions as shipmentQuestions } from './data/questions.js';
+import { loadQuestionsFromGist } from './data/gistLoader.js';
 
 dotenv.config();
 
 const bot = new Telegraf(process.env.BOT_TOKEN);
 
-// In-memory session storage (לא צריך DB)
+// ============================================================
+// Multi-repo registry
+// ============================================================
+// Each repo entry has: name, categories, questions.
+// The 'shipment' repo is loaded from the local file.
+// Additional repos are loaded from gists on startup.
+const repos = {
+  shipment: {
+    name: '📦 Shipment Bot',
+    categories: shipmentCategories,
+    questions: shipmentQuestions
+  }
+};
+
+// Gist-based repos to load on startup
+const gistRepos = [
+  { key: 'codebot', name: '🤖 CodeBot', gistId: '01dbd8d9de54cb4cccf6a5cb646e523c' }
+];
+
+async function loadGistRepos() {
+  for (const { key, name, gistId } of gistRepos) {
+    try {
+      const data = await loadQuestionsFromGist(gistId);
+      repos[key] = { name, categories: data.categories, questions: data.questions };
+      console.log(`✅ Loaded repo "${name}" from gist (${data.questions.length} questions)`);
+    } catch (err) {
+      console.error(`❌ Failed to load repo "${name}" from gist ${gistId}:`, err.message);
+    }
+  }
+}
+
+// ============================================================
+// HTML escaping - fixes TelegramError for tags in question text
+// ============================================================
+function escapeHTML(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// ============================================================
+// In-memory session storage
+// ============================================================
 const sessions = new Map();
 
-// Helper functions
 function getSession(userId) {
   if (!sessions.has(userId)) {
     sessions.set(userId, {
@@ -17,7 +60,8 @@ function getSession(userId) {
       score: 0,
       answered: 0,
       category: null,
-      questionIndex: -1
+      questionIndex: -1,
+      repo: null // selected repo key
     });
   }
   return sessions.get(userId);
@@ -27,26 +71,31 @@ function resetSession(userId) {
   sessions.delete(userId);
 }
 
-function getNextQuestion(category = null, currentIndex = -1) {
+// ============================================================
+// Quiz helpers (repo-aware)
+// ============================================================
+function getRepoData(session) {
+  const key = session.repo || 'shipment';
+  return repos[key] || repos.shipment;
+}
+
+function getNextQuestion(repoData, category = null, currentIndex = -1) {
   const filtered = category
-    ? questions.filter(q => q.category === category)
-    : questions;
+    ? repoData.questions.filter(q => q.category === category)
+    : repoData.questions;
 
-  // Get next index in sequence
+  if (filtered.length === 0) return null;
+
   const nextIndex = (currentIndex + 1) % filtered.length;
-
-  return {
-    question: filtered[nextIndex],
-    nextIndex: nextIndex
-  };
+  return { question: filtered[nextIndex], nextIndex };
 }
 
 function formatQuestion(question) {
-  let text = `📝 <b>שאלה:</b>\n${question.question}\n\n`;
+  let text = `📝 <b>שאלה:</b>\n${escapeHTML(question.question)}\n\n`;
 
   if (question.type === 'multiple') {
     question.options.forEach((opt, idx) => {
-      text += `${idx + 1}. ${opt}\n`;
+      text += `${idx + 1}. ${escapeHTML(opt)}\n`;
     });
     text += '\n💡 שלח מספר (1-4)';
   } else if (question.type === 'truefalse') {
@@ -57,12 +106,44 @@ function formatQuestion(question) {
   return text;
 }
 
+// ============================================================
+// Helper: show repo selection keyboard
+// ============================================================
+function repoSelectionKeyboard() {
+  const buttons = Object.keys(repos).map(key => (
+    [Markup.button.callback(repos[key].name, `repo_${key}`)]
+  ));
+  return Markup.inlineKeyboard(buttons);
+}
+
+// ============================================================
+// Helper: show category keyboard for current repo
+// ============================================================
+function categoryKeyboard(session) {
+  const repoData = getRepoData(session);
+  const keyboard = Object.keys(repoData.categories).map(key => {
+    const cat = repoData.categories[key];
+    return [Markup.button.callback(cat.name, `cat_${key}`)];
+  });
+  keyboard.push([Markup.button.callback('🎲 שאלה רנדומלית', 'random')]);
+  keyboard.push([Markup.button.callback('🔀 החלף ריפו', 'select_repo')]);
+  return Markup.inlineKeyboard(keyboard);
+}
+
+// ============================================================
 // Commands
+// ============================================================
 bot.command('start', (ctx) => {
   resetSession(ctx.from.id);
-  
-  const welcomeText = `
-🎓 <b>ברוכים הבאים לבוט החידון של Shipment Bot!</b>
+
+  if (Object.keys(repos).length === 1) {
+    // Only one repo available - go straight to quiz
+    const session = getSession(ctx.from.id);
+    session.repo = Object.keys(repos)[0];
+    const repoData = getRepoData(session);
+
+    const welcomeText = `
+🎓 <b>ברוכים הבאים לבוט החידון של ${escapeHTML(repoData.name)}!</b>
 
 בוט זה עוזר לך ללמוד את המבנה והארכיטקטורה של הפרויקט.
 
@@ -73,38 +154,77 @@ bot.command('start', (ctx) => {
 /reset - אפס סטטיסטיקות
 
 📚 <b>קטגוריות:</b>
-${Object.values(categories).map(c => c.name).join('\n')}
+${Object.values(repoData.categories).map(c => c.name).join('\n')}
 
 בהצלחה! 🚀
-  `;
+    `;
+    ctx.replyWithHTML(welcomeText);
+  } else {
+    // Multiple repos - let user choose
+    const welcomeText = `
+🎓 <b>ברוכים הבאים לבוט החידון!</b>
 
-  ctx.replyWithHTML(welcomeText);
+בוט זה עוזר לך ללמוד את המבנה והארכיטקטורה של פרויקטים שונים.
+
+🎯 <b>פקודות זמינות:</b>
+/repo - בחר פרויקט
+/category - בחר קטגוריה
+/random - שאלה רנדומלית
+/stats - סטטיסטיקות (סשן נוכחי)
+/reset - אפס סטטיסטיקות
+
+📂 בחר פרויקט כדי להתחיל:
+    `;
+    ctx.replyWithHTML(welcomeText, repoSelectionKeyboard());
+  }
+});
+
+bot.command('repo', (ctx) => {
+  if (Object.keys(repos).length <= 1) {
+    ctx.reply('📦 יש רק פרויקט אחד זמין כרגע.');
+    return;
+  }
+  ctx.reply('📂 בחר פרויקט:', repoSelectionKeyboard());
 });
 
 bot.command('category', (ctx) => {
-  const keyboard = Object.keys(categories).map(key => {
-    const cat = categories[key];
-    return [Markup.button.callback(cat.name, `cat_${key}`)];
-  });
-  
-  keyboard.push([Markup.button.callback('🎲 שאלה רנדומלית', 'random')]);
-  
-  ctx.reply(
-    '📚 בחר קטגוריה:',
-    Markup.inlineKeyboard(keyboard)
-  );
+  const session = getSession(ctx.from.id);
+
+  if (!session.repo) {
+    if (Object.keys(repos).length === 1) {
+      session.repo = Object.keys(repos)[0];
+    } else {
+      ctx.reply('📂 בחר פרויקט קודם:', repoSelectionKeyboard());
+      return;
+    }
+  }
+
+  ctx.reply('📚 בחר קטגוריה:', categoryKeyboard(session));
 });
 
 bot.command('random', (ctx) => {
   const session = getSession(ctx.from.id);
 
-  // Reset index when switching to random mode
+  if (!session.repo) {
+    if (Object.keys(repos).length === 1) {
+      session.repo = Object.keys(repos)[0];
+    } else {
+      ctx.reply('📂 בחר פרויקט קודם:', repoSelectionKeyboard());
+      return;
+    }
+  }
+
   if (session.category !== null) {
     session.questionIndex = -1;
     session.category = null;
   }
 
-  const result = getNextQuestion(null, session.questionIndex);
+  const repoData = getRepoData(session);
+  const result = getNextQuestion(repoData, null, session.questionIndex);
+  if (!result) {
+    ctx.reply('⚠️ אין שאלות זמינות.');
+    return;
+  }
   session.currentQuestion = result.question;
   session.questionIndex = result.nextIndex;
 
@@ -113,13 +233,16 @@ bot.command('random', (ctx) => {
 
 bot.command('stats', (ctx) => {
   const session = getSession(ctx.from.id);
-  
-  const percentage = session.answered > 0 
+  const repoData = getRepoData(session);
+
+  const percentage = session.answered > 0
     ? Math.round((session.score / session.answered) * 100)
     : 0;
-  
+
+  const repoLabel = session.repo ? `\n📂 פרויקט: ${escapeHTML(repoData.name)}` : '';
+
   const statsText = `
-📊 <b>הסטטיסטיקות שלך:</b>
+📊 <b>הסטטיסטיקות שלך:</b>${repoLabel}
 
 ✅ נכונות: ${session.score}
 📝 סה"כ שאלות: ${session.answered}
@@ -136,19 +259,71 @@ bot.command('reset', (ctx) => {
   ctx.reply('🔄 הסטטיסטיקות אופסו בהצלחה!');
 });
 
+// ============================================================
+// Repo selection action
+// ============================================================
+bot.action(/^repo_(.+)$/, (ctx) => {
+  const repoKey = ctx.match[1];
+  if (!repos[repoKey]) {
+    ctx.answerCbQuery('פרויקט לא נמצא');
+    return;
+  }
+
+  const session = getSession(ctx.from.id);
+  const previousRepo = session.repo;
+
+  // Reset quiz progress when switching repos
+  if (previousRepo !== repoKey) {
+    session.category = null;
+    session.questionIndex = -1;
+    session.currentQuestion = null;
+  }
+  session.repo = repoKey;
+
+  const repoData = repos[repoKey];
+
+  ctx.answerCbQuery();
+  ctx.replyWithHTML(
+    `📂 <b>פרויקט: ${escapeHTML(repoData.name)}</b>\n\n📚 בחר קטגוריה:`,
+    categoryKeyboard(session)
+  );
+});
+
+bot.action('select_repo', (ctx) => {
+  ctx.answerCbQuery();
+  ctx.reply('📂 בחר פרויקט:', repoSelectionKeyboard());
+});
+
+// ============================================================
 // Category selection handlers
+// ============================================================
 bot.action(/^cat_(.+)$/, (ctx) => {
   const category = ctx.match[1];
   const session = getSession(ctx.from.id);
 
-  // Reset index when switching category
+  if (!session.repo) {
+    if (Object.keys(repos).length === 1) {
+      session.repo = Object.keys(repos)[0];
+    } else {
+      ctx.answerCbQuery();
+      ctx.reply('📂 בחר פרויקט קודם:', repoSelectionKeyboard());
+      return;
+    }
+  }
+
   if (session.category !== category) {
     session.questionIndex = -1;
   }
 
   session.category = category;
 
-  const result = getNextQuestion(category, session.questionIndex);
+  const repoData = getRepoData(session);
+  const result = getNextQuestion(repoData, category, session.questionIndex);
+  if (!result) {
+    ctx.answerCbQuery();
+    ctx.reply('⚠️ אין שאלות בקטגוריה זו.');
+    return;
+  }
   session.currentQuestion = result.question;
   session.questionIndex = result.nextIndex;
 
@@ -159,13 +334,28 @@ bot.action(/^cat_(.+)$/, (ctx) => {
 bot.action('random', (ctx) => {
   const session = getSession(ctx.from.id);
 
-  // Reset index when switching to random mode
+  if (!session.repo) {
+    if (Object.keys(repos).length === 1) {
+      session.repo = Object.keys(repos)[0];
+    } else {
+      ctx.answerCbQuery();
+      ctx.reply('📂 בחר פרויקט קודם:', repoSelectionKeyboard());
+      return;
+    }
+  }
+
   if (session.category !== null) {
     session.questionIndex = -1;
     session.category = null;
   }
 
-  const result = getNextQuestion(null, session.questionIndex);
+  const repoData = getRepoData(session);
+  const result = getNextQuestion(repoData, null, session.questionIndex);
+  if (!result) {
+    ctx.answerCbQuery();
+    ctx.reply('⚠️ אין שאלות זמינות.');
+    return;
+  }
   session.currentQuestion = result.question;
   session.questionIndex = result.nextIndex;
 
@@ -173,19 +363,21 @@ bot.action('random', (ctx) => {
   ctx.replyWithHTML(formatQuestion(result.question));
 });
 
+// ============================================================
 // Answer handling
+// ============================================================
 bot.on('text', (ctx) => {
   const session = getSession(ctx.from.id);
-  
+
   if (!session.currentQuestion) {
     ctx.reply('❓ אין שאלה פעילה. השתמש ב-/random או /category כדי להתחיל');
     return;
   }
-  
+
   const question = session.currentQuestion;
   const answer = ctx.message.text.trim();
   let isCorrect = false;
-  
+
   if (question.type === 'multiple') {
     const answerNum = parseInt(answer);
     if (answerNum >= 1 && answerNum <= question.options.length) {
@@ -205,77 +397,84 @@ bot.on('text', (ctx) => {
       return;
     }
   }
-  
+
   // Update stats
   session.answered++;
   if (isCorrect) {
     session.score++;
   }
-  
-  // Build response
+
+  // Build response (escape dynamic content that may contain HTML chars)
   let response = isCorrect
     ? '✅ <b>תשובה נכונה!</b>\n\n'
     : '❌ <b>תשובה שגויה</b>\n\n';
 
   if (question.type === 'multiple' && !isCorrect) {
-    response += `התשובה הנכונה: ${question.options[question.correct]}\n\n`;
+    response += `התשובה הנכונה: ${escapeHTML(question.options[question.correct])}\n\n`;
   } else if (question.type === 'truefalse' && !isCorrect) {
     response += `התשובה הנכונה: ${question.correct ? 'נכון' : 'לא נכון'}\n\n`;
   }
 
-  response += `💡 <b>הסבר:</b>\n${question.explanation}\n\n`;
+  response += `💡 <b>הסבר:</b>\n${escapeHTML(question.explanation)}\n\n`;
   response += `📊 ציון נוכחי: ${session.score}/${session.answered}`;
 
   // Send response with next question button
+  const nextAction = session.category ? `cat_${session.category}` : 'random';
   const keyboard = Markup.inlineKeyboard([
-    [Markup.button.callback('➡️ שאלה הבאה', session.category ? `cat_${session.category}` : 'random')],
-    [Markup.button.callback('📚 שנה קטגוריה', 'change_category')]
+    [Markup.button.callback('➡️ שאלה הבאה', nextAction)],
+    [Markup.button.callback('📚 שנה קטגוריה', 'change_category')],
+    ...(Object.keys(repos).length > 1 ? [[Markup.button.callback('🔀 החלף ריפו', 'select_repo')]] : [])
   ]);
 
   ctx.replyWithHTML(response, keyboard);
-  
+
   // Clear current question
   session.currentQuestion = null;
 });
 
 bot.action('change_category', (ctx) => {
-  const keyboard = Object.keys(categories).map(key => {
-    const cat = categories[key];
-    return [Markup.button.callback(cat.name, `cat_${key}`)];
-  });
-  
-  keyboard.push([Markup.button.callback('🎲 שאלה רנדומלית', 'random')]);
-  
+  const session = getSession(ctx.from.id);
   ctx.answerCbQuery();
-  ctx.reply(
-    '📚 בחר קטגוריה:',
-    Markup.inlineKeyboard(keyboard)
-  );
+  ctx.reply('📚 בחר קטגוריה:', categoryKeyboard(session));
 });
 
+// ============================================================
 // Error handling
+// ============================================================
 bot.catch((err, ctx) => {
   console.error('Bot error:', err);
   ctx.reply('⚠️ אירעה שגיאה. נסה שוב מאוחר יותר.');
 });
 
+// ============================================================
 // Launch
+// ============================================================
 const PORT = process.env.PORT || 3000;
 
-if (process.env.WEBHOOK_DOMAIN) {
-  // Webhook mode for Render
-  bot.launch({
-    webhook: {
-      domain: process.env.WEBHOOK_DOMAIN,
-      port: PORT
-    }
-  });
-  console.log(`🤖 Bot started in webhook mode on port ${PORT}`);
-} else {
-  // Polling mode for local development
-  bot.launch();
-  console.log('🤖 Bot started in polling mode');
+async function start() {
+  // Load gist-based repos before starting the bot
+  await loadGistRepos();
+
+  if (process.env.WEBHOOK_DOMAIN) {
+    bot.launch({
+      webhook: {
+        domain: process.env.WEBHOOK_DOMAIN,
+        port: PORT
+      }
+    });
+    console.log(`🤖 Bot started in webhook mode on port ${PORT}`);
+  } else {
+    bot.launch();
+    console.log('🤖 Bot started in polling mode');
+  }
+
+  console.log(`📚 Available repos: ${Object.keys(repos).join(', ')}`);
 }
+
+start().catch(err => {
+  console.error('Failed to start bot:', err);
+  process.exit(1);
+});
 
 // Graceful shutdown
 process.once('SIGINT', () => bot.stop('SIGINT'));


### PR DESCRIPTION

הכל בוצע ונדחף ל-branch. הנה סיכום של מה שנעשה:

## מה מומש

### 1. תיקון באג HTML Escaping
- הוספת פונקציית `escapeHTML()` שמבצעת escape לתווי `<`, `>`, `&` בטקסט של שאלות, אפשרויות, והסברים
- זה פותר את ה-`TelegramError: can't parse entities: Can't find end tag corresponding to start tag 'em'` שקורה כששאלות מכילות תגיות HTML כמו `<b>`, `<em>`, `<strong>` בתוכן שלהן (למשל שאלה `wh_3` על המרת HTML לפורמט WhatsApp)

### 2. תמיכה במולטי-ריפו
- **קובץ חדש**: `src/data/gistLoader.js` - טוען שאלות מ-GitHub Gists דרך ה-API
- **רישום ריפו**: מערכת רישום שתומכת ב:
  - ריפו מקומי (Shipment Bot - מהקובץ הקיים)
  - ריפו מבוסס Gist (CodeBot - מה-gist שצוין ב-issue)
- **פקודה `/repo`** חדשה לבחירת פרויקט
- **כפתורי inline** לבחירה ומעבר בין פרויקטים
- Session מכיל עכשיו שדה `repo` שעוקב אחרי הפרויקט הנוכחי
- מעבר בין ריפו מאפס את הקטגוריה ואינדקס השאלות

### 3. נורמליזציה של סוגי שאלות
- ה-gist של CodeBot משתמש ב-`type: 'boolean'` במקום `type: 'truefalse'` - הממיר מנרמל אוטומטית

### 4. הוספת CodeBot כריפו
- ה-gist `01dbd8d9de54cb4cccf6a5cb646e523c` נטען אוטומטית ב-startup
- אם הטעינה נכשלת, הבוט ממשיך לעבוד עם הריפו המקומי בלבד

## Summary
This PR extends the quiz bot to support multiple question repositories, with the ability to dynamically load quiz data from GitHub Gists. The bot now maintains a registry of repos and allows users to switch between them.

## Key Changes

- **Multi-repo architecture**: Introduced a `repos` registry that stores multiple quiz repositories, each with its own categories and questions
- **Gist-based question loading**: Added `gistLoader.js` module that fetches and parses quiz data from GitHub Gists, supporting both `categories` and `questions` exports
- **Dynamic repo initialization**: Repos are loaded asynchronously on bot startup, with graceful error handling for failed loads
- **User repo selection**: Added `/repo` command and repo selection UI (inline keyboard) to allow users to switch between available repositories
- **Session-aware repo tracking**: Extended session storage to track the currently selected repo per user, with automatic reset of quiz progress when switching repos
- **HTML escaping**: Implemented `escapeHTML()` function to safely handle special characters in question text, options, and explanations, preventing Telegram API errors
- **Improved UI/UX**: 
  - Repo selection keyboard shown on `/start` when multiple repos are available
  - Category keyboard now includes "Change repo" button when multiple repos exist
  - Welcome message adapts based on number of available repos
  - Stats display shows current repo name

## Implementation Details

- The `loadQuestionsFromGist()` function handles GitHub API calls and raw content fetching with redirect support
- Question type normalization converts `'boolean'` type to `'truefalse'` for consistency
- All user-facing text content is HTML-escaped to prevent Telegram parsing errors
- Repo switching automatically resets quiz progress (category, question index) to prevent confusion
- The shipment repo remains as the default/fallback repo
- Gist repos are configured via the `gistRepos` array and can be easily extended

https://claude.ai/code/session_01WmZxbho1Z19VWv9MbQdAnU